### PR TITLE
Add debug logs for player name modal

### DIFF
--- a/client/Game.js
+++ b/client/Game.js
@@ -103,6 +103,7 @@ class Game extends Phaser.Scene {
 
         // establish socket connection
         this.socket = io();
+        console.log('Requesting player name');
         this.showNameModal();
         this.socket.on('connect', () => {
             this.socket.emit('getPlayersList', { x: 0, y: 0 });
@@ -120,6 +121,7 @@ class Game extends Phaser.Scene {
             }
         });
         this.socket.on('initialize', (data) => {
+            console.log('Received initialization data:', data);
             const team = data.team;
             const coins = data.coins;
             const circleColor = team === 'blue' ? 0x0000ff : 0xff0000;
@@ -212,10 +214,13 @@ class Game extends Phaser.Scene {
         const input = document.getElementById('playerNameInput');
         const button = document.getElementById('submitNameButton');
 
+        console.log('Displaying name modal');
         modal.style.display = 'flex'; // Ensure the modal is displayed
 
         button.addEventListener('click', () => {
+            console.log('Connect button clicked');
             const playerName = input.value.trim();
+            console.log('Entered player name:', playerName);
             if (playerName) {
                 // Send the player name to the server
                 this.socket.emit('newName', { name: playerName });

--- a/src/game/game.gateway.ts
+++ b/src/game/game.gateway.ts
@@ -108,14 +108,14 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     //welcome new player!
     handleConnection(client: Socket) {
-
+        console.log('Client connected:', client.id);
         this.server.emit('updatePlayersList', this.players); // Send the updated player list to all clients
         this.server.emit('updateBubbiesList', this.bubbies);
         //a player wants to move something, lets see if they are owner and if we can let them
 
         //Register new player once they send their name
         client.on('newName', (data: { name: string }) => {
-            console.log(data.name, " = data.newName");
+            console.log('Received newName from', client.id, 'name:', data.name);
             // Update the player's name
           //  this.players[client.id].name = data.name;
          
@@ -126,7 +126,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             let coins = 1000;
             // Add the new player to the list with the determined team
             this.players[client.id] = { name: data.name, x: 0, y: 0, team, coins, isBuilding: false, isInGame: true }; // Initialize with default position and team
-            console.log(this.players[client.id].name, " has joined the game");
+            console.log(this.players[client.id].name, "has joined the game on team", team);
             if (team === 'blue') {
                 this.teamCounts.blue++;
             } else {
@@ -134,6 +134,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
             }
             //set up newly connected player
             this.server.to(client.id).emit('initialize', { team, coins }); // Send team assignment and coins to the new client
+            console.log('Initialization data sent to', client.id);
         });
         //Only let connected clients that are in the game play
         // if (this.players[client.id].isInGame) {
@@ -222,6 +223,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     handleDisconnect(client: Socket) {
+        console.log('Client disconnected:', client.id);
         // Release control of the bubby if the disconnecting player was controlling one
         for (const bubbyId in this.bubbies) {
             const bubby = this.bubbies[bubbyId];


### PR DESCRIPTION
## Summary
- log when the name modal is displayed and when the Connect button is used
- log initialization data from the server
- log connection, newName, initialization, and disconnect events on the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684057d6f1a883299ffd35592aa6474b